### PR TITLE
Refactor: Update fragment_appointment_edit.xml layout

### DIFF
--- a/app/src/main/res/layout/fragment_appointment_edit.xml
+++ b/app/src/main/res/layout/fragment_appointment_edit.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    >
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
         <variable
@@ -14,21 +13,24 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@android:color/white"
+        android:fitsSystemWindows="true"
+        android:paddingTop="0dp"
         tools:context=".view.fragment.AppointmentEditFragment">
 
-        <!-- Toolbar  redondeado -->
+        <!-- Toolbar redondeado -->
         <androidx.cardview.widget.CardView
             android:id="@+id/toolbar"
             android:layout_width="0dp"
             android:layout_height="145dp"
             android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
+            android:layout_marginTop="25dp"
             android:layout_marginEnd="16dp"
             app:cardPreventCornerOverlap="true"
             app:cardUseCompatPadding="true"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toTopOf="parent"
+            tools:ignore="ExtraText">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
@@ -41,11 +43,12 @@
                     android:layout_width="34dp"
                     android:layout_height="34dp"
                     android:layout_marginStart="24dp"
+                    android:contentDescription="@null"
                     android:src="@drawable/ic_arrow_back"
-                    android:tint="@color/pink"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:tint="@color/pink" />
 
                 <!-- Título -->
                 <TextView
@@ -58,9 +61,10 @@
                     android:textStyle="bold"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintHorizontal_bias="0.5"
+                    app:layout_constraintHorizontal_bias="0.353"
                     app:layout_constraintStart_toEndOf="@id/backButton"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintVertical_bias="0.495" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.cardview.widget.CardView>
 
@@ -80,7 +84,8 @@
             app:hintTextColor="@color/grisOscuro"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/toolbar">
+            app:layout_constraintTop_toBottomOf="@id/toolbar"
+            app:layout_constraintWidth_max="600dp">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/mascotaName"
@@ -88,8 +93,8 @@
                 android:layout_height="wrap_content"
                 android:inputType="text"
                 android:maxLength="15"
-                android:text="@={viewModel.petName}"
-                android:textColor="@android:color/black" />
+                android:textColor="#212121"
+                android:textColorHint="#666666" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <!-- Campo: Raza (AutoComplete) -->
@@ -108,15 +113,19 @@
             app:hintTextColor="@color/grisOscuro"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/mascotaNameLayout">
+            app:layout_constraintTop_toBottomOf="@id/mascotaNameLayout"
+            app:layout_constraintWidth_max="600dp">
 
-            <AutoCompleteTextView
+            <com.google.android.material.textfield.MaterialAutoCompleteTextView
                 android:id="@+id/razaAutoComplete"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="text"
-                android:text="@={viewModel.breed}"
-                android:textColor="@android:color/black"
+                android:minHeight="48dp"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:textColor="#212121"
+                android:textColorHint="#666666"
                 tools:ignore="LabelFor" />
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -136,7 +145,8 @@
             app:hintTextColor="@color/grisOscuro"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/razaLayout">
+            app:layout_constraintTop_toBottomOf="@id/razaLayout"
+            app:layout_constraintWidth_max="600dp">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/propietarioName"
@@ -144,8 +154,8 @@
                 android:layout_height="wrap_content"
                 android:inputType="text"
                 android:maxLength="30"
-                android:text="@={viewModel.ownerName}"
-                android:textColor="@android:color/black" />
+                android:textColor="#212121"
+                android:textColorHint="#666666" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <!-- Campo: Teléfono -->
@@ -164,7 +174,8 @@
             app:hintTextColor="@color/grisOscuro"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/propietarioNameLayout">
+            app:layout_constraintTop_toBottomOf="@id/propietarioNameLayout"
+            app:layout_constraintWidth_max="600dp">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/telefono"
@@ -172,8 +183,8 @@
                 android:layout_height="wrap_content"
                 android:inputType="phone"
                 android:maxLength="10"
-                android:text="@={viewModel.phone}"
-                android:textColor="@android:color/black" />
+                android:textColor="#212121"
+                android:textColorHint="#666666" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <!-- Botón Editar Cita -->
@@ -185,11 +196,10 @@
             android:layout_marginTop="32dp"
             android:layout_marginEnd="32dp"
             android:layout_marginBottom="16dp"
-            android:enabled="@{viewModel.isFormValid}"
             android:text="@string/editar_cita"
             android:textAllCaps="false"
-            android:textColor="@{viewModel.isFormValid ? @android:color/white : @color/grisOscuro}"
             android:textStyle="bold"
+            android:contentDescription="@null"
             app:backgroundTint="@color/pink"
             app:cornerRadius="24dp"
             app:icon="@drawable/ic_edit"
@@ -197,6 +207,5 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/telefonoLayout" />
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
This commit refactors the `fragment_appointment_edit.xml` layout file.

Changes include:
- Updated the root ConstraintLayout padding and added `fitsSystemWindows="true"`.
- Adjusted the top margin of the toolbar CardView.
- Added `android:contentDescription="@null"` to the back button ImageView and the "Editar Cita" Button.
- Updated the tint color application method for the back button.
- Adjusted horizontal and vertical bias for the toolbar title TextView.
- Added `app:layout_constraintWidth_max="600dp"` to the TextInputLayouts for better large screen handling.
- Removed `android:text="@={viewModel.petName}"` and other data binding expressions from the input fields.
- Changed TextInputEditText and AutoCompleteTextView text and hint text colors to specific values.
- Replaced `AutoCompleteTextView` with `com.google.android.material.textfield.MaterialAutoCompleteTextView` for the breed field.
- Added padding and minimum height to the breed AutoCompleteTextView.
- Removed the `android:enabled` and `android:textColor` data binding expressions from the "Editar Cita" Button.
![fragment_appointment_edit (2)](https://github.com/user-attachments/assets/0cd18ad7-25a8-4849-8ad0-e900ed00f702)

https://github.com/user-attachments/assets/34869a69-5387-4370-846b-020039dd3583

