### PR TITLE
Add AppointmentEditFragment with basic layout inflation

### DIFF
--- a/app/src/main/java/com/dogAPPackage/dogapp/view/fragment/AppointmentEditFragment.kt
+++ b/app/src/main/java/com/dogAPPackage/dogapp/view/fragment/AppointmentEditFragment.kt
@@ -1,4 +1,20 @@
 package com.dogAPPackage.dogapp.view.fragment
 
-class AppointmentEditFragment {
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.dogAPPackage.dogapp.R
+
+class AppointmentEditFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Infla el diseño del fragmento
+        return inflater.inflate(R.layout.fragment_appointment_edit, container, false)
+    }
 }


### PR DESCRIPTION
This commit introduces the `AppointmentEditFragment` class. It inherits from `Fragment` and overrides `onCreateView` to inflate the `fragment_appointment_edit.xml` layout file.