### PR TITLE
Add data class for DogBreedsResponse

### DIFF
--- a/app/src/main/java/com/dogAPPackage/dogapp/model/DogBreedsResponse.kt
+++ b/app/src/main/java/com/dogAPPackage/dogapp/model/DogBreedsResponse.kt
@@ -1,0 +1,7 @@
+package com.dogAPPackage.dogapp.model
+
+// Este modelo representa la respuesta JSON de la API de razas de perros
+data class DogBreedsResponse(
+    val message: Map<String, List<String>>,
+    val status: String
+)


### PR DESCRIPTION
This commit introduces the `DogBreedsResponse` data class in `DogBreedsResponse.kt`. This class models the JSON response structure expected from the dog breeds API, including a map of breed names to sub-breeds and a status string.