### PR TITLE
Update Base URL in Constants

### DIFF
--- a/app/src/main/java/com/dogAPPackage/dogapp/utils/Constants.kt
+++ b/app/src/main/java/com/dogAPPackage/dogapp/utils/Constants.kt
@@ -2,7 +2,7 @@ package com.dogAPPackage.dogapp.utils
 
 object Constants {
     const val NAME_BD: String ="app_data.db"
-    const val BASE_URL="https://fakestoreapi.com/"
+    const val BASE_URL="https://dog.ceo/api/"
     const val END_POINT="appointments"
 
 }


### PR DESCRIPTION
This commit updates the `BASE_URL` constant in `Constants.kt` from "https://fakestoreapi.com/" to "https://dog.ceo/api/".