### PR TITLE
Add getAppointmentById function

### DIFF
--- a/app/src/main/java/com/dogAPPackage/dogapp/data/AppointmentDao.kt
+++ b/app/src/main/java/com/dogAPPackage/dogapp/data/AppointmentDao.kt
@@ -22,4 +22,9 @@ interface AppointmentDao {
 
     @Update
     suspend fun updateAppointment(appointment: Appointment)
+
+    //Consultar por id para  editar
+    @Query("SELECT * FROM Appointment WHERE id = :id")
+    suspend fun getAppointmentById(id: Int): Appointment?
+
 }


### PR DESCRIPTION
This commit adds a new function `getAppointmentById` to the `AppointmentDao` interface. This function is used to retrieve an appointment from the database based on its unique ID.