### PR TITLE
Update ApiService function name

### DIFF
--- a/app/src/main/java/com/dogAPPackage/dogapp/webservice/ApiService.kt
+++ b/app/src/main/java/com/dogAPPackage/dogapp/webservice/ApiService.kt
@@ -8,7 +8,7 @@ import retrofit2.http.Path
 
 interface ApiService {
     @GET(END_POINT)
-    suspend fun getProducts(): MutableList<AppointmentModelResponse>
+    suspend fun getAppointments(): MutableList<AppointmentModelResponse>
 
     @GET("breeds/list/all")
     suspend fun getAllBreeds(): DogBreedsResponse


### PR DESCRIPTION
Renamed the `getProducts` function to `getAppointments` in the `ApiService` interface to better reflect its purpose of fetching appointment data.