### PR TITLE
Add BreedResponse data class

### DIFF
--- a/app/src/main/java/com/dogAPPackage/dogapp/model/BreedResponse.kt
+++ b/app/src/main/java/com/dogAPPackage/dogapp/model/BreedResponse.kt
@@ -1,3 +1,5 @@
+package com.dogAPPackage.dogapp.model
+
 data class BreedResponse(
     val message: Map<String, List<String>>,
     val status: String


### PR DESCRIPTION
This commit introduces the `BreedResponse` data class in the `com.dogAPPackage.dogapp.model` package. It is designed to model the response structure from a dog breed API, containing:
- `message`: A map where keys are dog breed names (String) and values are lists of sub-breeds (List<String>).
- `status`: A string indicating the status of the API call.