### PR TITLE
Add and implement appointment edit fragment

### DIFF
--- a/app/src/main/java/com/dogAPPackage/dogapp/view/fragment/AppointmentEditFragment.kt
+++ b/app/src/main/java/com/dogAPPackage/dogapp/view/fragment/AppointmentEditFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.lifecycleScope
 import android.text.TextWatcher
 import android.text.Editable
 import androidx.core.content.ContextCompat
+import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
 import com.dogAPPackage.dogapp.R
 import com.dogAPPackage.dogapp.model.Appointment
@@ -25,7 +26,7 @@ import kotlinx.coroutines.withContext
 class AppointmentEditFragment : Fragment() {
 
     private val viewModel: AppointmentViewModel by viewModels()
-    private var appointmentId: Int = -1
+    private var appointmentId: Int = 10 //precargar los datos de la cita a editar
 
     private lateinit var mascotaName: EditText
     private lateinit var razaAutoComplete: AutoCompleteTextView
@@ -41,7 +42,7 @@ class AppointmentEditFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         arguments?.let {
-            appointmentId = it.getInt("appointmentId", -1)
+            appointmentId = it.getInt("appointmentId", appointmentId)
         }
 
         if (appointmentId != -1) {
@@ -96,7 +97,7 @@ class AppointmentEditFragment : Fragment() {
             )
             viewModel.updateAppointment(updatedAppointment)
             Toast.makeText(requireContext(), "Cita actualizada", Toast.LENGTH_SHORT).show()
-            requireActivity().onBackPressedDispatcher.onBackPressed()
+            findNavController().navigate(R.id.action_appointmentEditFragment_to_homeFragment) // Ir a la pantalla de inicio (Home)
         }
 
         // Manejo del botón de retroceso

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -35,4 +35,16 @@
             app:destination="@id/homeFragment" />
     </fragment>
 
+
+<!-- This is the fragment for editing an appointment -->
+    <fragment
+        android:id="@+id/appointmentEditFragment"
+        android:name="com.dogAPPackage.dogapp.view.fragment.AppointmentEditFragment"
+        android:label="Editar Cita"
+        tools:layout="@layout/fragment_appointment_edit">
+
+        <action
+            android:id="@+id/action_appointmentEditFragment_to_homeFragment"
+            app:destination="@id/homeFragment" />
+    </fragment>
 </navigation>


### PR DESCRIPTION
This commit adds the `AppointmentEditFragment` and integrates it into the navigation graph.

Changes include:
- Added `appointmentEditFragment` to `nav_graph.xml` with an action to navigate back to the `homeFragment`.
- Created `AppointmentEditFragment.kt` which handles fetching, displaying, and updating appointment details.
- Implemented form validation for the input fields.
- Added functionality to load existing appointment data for editing.
- Included a listener for the edit button to update the appointment in the database and navigate back to the home screen.
- Set up a back button listener to navigate back to the home screen without saving changes.
- Configured the auto-completion for dog breeds.