### PR TITLE
Navigation: Ajuste de navegación en la aplicación

### DIFF
--- a/app/src/main/java/com/dogAPPackage/dogapp/view/adapter/AppointmentAdapter.kt
+++ b/app/src/main/java/com/dogAPPackage/dogapp/view/adapter/AppointmentAdapter.kt
@@ -31,11 +31,10 @@ class AppointmentAdapter(
         holder.bind(appointment)
 
         holder.itemView.setOnClickListener {
-            // Navegar al fragmento de edición y pasar el appointmentId
             val bundle = Bundle().apply {
                 putInt("appointmentId", appointment.id)
             }
-            navController.navigate(R.id.action_homeAppointmentFragment_to_appointmentEditFragment, bundle)
+            navController.navigate(R.id.action_homeAppointmentFragment_to_appointmentDetailsFragment, bundle)
         }
     }
 

--- a/app/src/main/java/com/dogAPPackage/dogapp/view/fragment/AddAppointmentFragment.kt
+++ b/app/src/main/java/com/dogAPPackage/dogapp/view/fragment/AddAppointmentFragment.kt
@@ -45,7 +45,7 @@ class AddAppointmentFragment : Fragment() {
         viewModel.getBreedsFromApi()
 
         binding.backButton.setOnClickListener {
-            findNavController().navigate(R.id.action_addAppointmentFragment_to_homeFragment)
+            findNavController().navigate(R.id.action_addAppointmentFragment_to_homeAppointmentFragment)
         }
 
         viewModel.breedsList.observe(viewLifecycleOwner) { breeds ->
@@ -138,7 +138,7 @@ class AddAppointmentFragment : Fragment() {
 
             Toast.makeText(requireContext(), "Cita guardada con éxito", Toast.LENGTH_SHORT).show()
 
-            findNavController().navigate(R.id.action_addAppointmentFragment_to_homeFragment)
+            findNavController().navigate(R.id.action_addAppointmentFragment_to_homeAppointmentFragment)
         }
     }
 }

--- a/app/src/main/java/com/dogAPPackage/dogapp/view/fragment/AppointmentEditFragment.kt
+++ b/app/src/main/java/com/dogAPPackage/dogapp/view/fragment/AppointmentEditFragment.kt
@@ -97,7 +97,7 @@ class AppointmentEditFragment : Fragment() {
             )
             viewModel.updateAppointment(updatedAppointment)
             Toast.makeText(requireContext(), "Cita actualizada", Toast.LENGTH_SHORT).show()
-            findNavController().navigate(R.id.action_appointmentEditFragment_to_homeFragment) // Ir a la pantalla de inicio (Home)
+            findNavController().navigate(R.id.action_appointmentEditFragment_to_homeAppointmentFragment) // Ir a la pantalla de inicio (Home)
         }
 
         // Manejo del botón de retroceso

--- a/app/src/main/java/com/dogAPPackage/dogapp/view/fragment/LoginFragment.kt
+++ b/app/src/main/java/com/dogAPPackage/dogapp/view/fragment/LoginFragment.kt
@@ -65,7 +65,7 @@ class LoginFragment : Fragment() {
                     showToast("Autenticación exitosa")
 
                     // Navegar al HomeFragment
-                    findNavController().navigate(R.id.action_loginFragment_to_homeFragment)
+                    findNavController().navigate(R.id.action_loginFragment_to_homeAppointmentFragment)
                 }
 
                 override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -5,51 +5,75 @@
     android:id="@+id/nav_graph"
     app:startDestination="@id/loginFragment">
 
+    <!-- HU 1.0: Login Fragment -->
     <fragment
         android:id="@+id/loginFragment"
         android:name="com.dogAPPackage.dogapp.view.fragment.LoginFragment"
         android:label="Login"
         tools:layout="@layout/fragment_login">
         <action
-            android:id="@+id/action_loginFragment_to_homeFragment"
-            app:destination="@id/homeFragment" />
+            android:id="@+id/action_loginFragment_to_homeAppointmentFragment"
+            app:destination="@id/homeAppointmentFragment"
+            app:popUpTo="@id/loginFragment"
+            app:popUpToInclusive="true" />
     </fragment>
 
-
+    <!-- HU 2.0: Home Fragment -->
     <fragment
-        android:id="@+id/homeFragment"
+        android:id="@+id/homeAppointmentFragment"
         android:name="com.dogAPPackage.dogapp.view.fragment.HomeAppointmentFragment"
-        android:label="Home"
+        android:label="Administrador de Citas"
         tools:layout="@layout/fragment_home_appointment">
         <action
             android:id="@+id/action_homeAppointmentFragment_to_addAppointmentFragment"
             app:destination="@id/addAppointmentFragment" />
         <action
-            android:id="@+id/action_homeAppointmentFragment_to_appointmentEditFragment"
-            app:destination="@id/appointmentEditFragment" />
+            android:id="@+id/action_homeAppointmentFragment_to_appointmentDetailsFragment"
+            app:destination="@id/appointmentDetailsFragment"
+
+            />
     </fragment>
 
-
+    <!-- HU 3.0: Agregar Cita -->
     <fragment
         android:id="@+id/addAppointmentFragment"
         android:name="com.dogAPPackage.dogapp.view.fragment.AddAppointmentFragment"
-        android:label="Add Appointment"
+        android:label="Nueva Cita"
         tools:layout="@layout/fragment_nueva_cita">
         <action
-            android:id="@+id/action_addAppointmentFragment_to_homeFragment"
-            app:destination="@id/homeFragment" />
+            android:id="@+id/action_addAppointmentFragment_to_homeAppointmentFragment"
+            app:destination="@id/homeAppointmentFragment"
+            app:popUpTo="@id/homeAppointmentFragment"
+            app:popUpToInclusive="true" />
     </fragment>
 
+    <!-- HU 4.0: Detalle de Cita -->
+    <fragment
+        android:id="@+id/appointmentDetailsFragment"
+        android:name="com.dogAPPackage.dogapp.view.fragment.AppointmentDetailsFragment"
+        android:label="Detalle de Cita"
+        tools:layout="@layout/fragment_appointment_details">
+        <action
+            android:id="@+id/action_appointmentDetailsFragment_to_homeAppointmentFragment"
+            app:destination="@id/homeAppointmentFragment"
+            app:popUpTo="@id/homeAppointmentFragment"
+            app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_appointmentDetailsFragment_to_appointmentEditFragment"
+            app:destination="@id/appointmentEditFragment" />
+    </fragment>
 
-<!-- This is the fragment for editing an appointment -->
+    <!-- HU 5.0: Editar Cita -->
     <fragment
         android:id="@+id/appointmentEditFragment"
         android:name="com.dogAPPackage.dogapp.view.fragment.AppointmentEditFragment"
         android:label="Editar Cita"
         tools:layout="@layout/fragment_appointment_edit">
-
         <action
-            android:id="@+id/action_appointmentEditFragment_to_homeFragment"
-            app:destination="@id/homeFragment" />
+            android:id="@+id/action_appointmentEditFragment_to_homeAppointmentFragment"
+            app:destination="@id/homeAppointmentFragment"
+            app:popUpTo="@id/homeAppointmentFragment"
+            app:popUpToInclusive="true" />
     </fragment>
+
 </navigation>


### PR DESCRIPTION
Se ajusta la navegación entre fragmentos en la aplicación:

- En `AppointmentAdapter`, se modifica la acción al hacer clic en un item para navegar a `appointmentDetailsFragment` en lugar de `appointmentEditFragment`.
- En `LoginFragment`, se cambia la navegación post-autenticación para ir a `homeAppointmentFragment` en lugar de `homeFragment`. Se añade `popUpTo` con `inclusive="true"` para limpiar el backstack.
- En `AppointmentEditFragment`, se ajusta la navegación después de guardar los cambios para regresar a `homeAppointmentFragment` en lugar de `homeFragment`. Se añade `popUpTo` con `inclusive="true"` para limpiar el backstack.
- En `AddAppointmentFragment`, se modifica la navegación al guardar una nueva cita o al presionar el botón de retroceso para ir a `homeAppointmentFragment` en lugar de `homeFragment`. Se añade `popUpTo` con `inclusive="true"` para limpiar el backstack.
- En `nav_graph.xml`, se actualizan las acciones de navegación para reflejar los cambios anteriores y se añaden comentarios para identificar los flujos de navegación por Historias de Usuario (HU). Se añade el fragmento `appointmentDetailsFragment`.