### PR TITLE
feat: Add CardView dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(libs.androidx.biometric.ktx)
     implementation(libs.androidx.navigation.fragment.ktx)
     implementation(libs.androidx.navigation.ui.ktx)
+    implementation(libs.cardview.v7)
     val navVersion = "2.3.5"
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ constraintlayout = "2.2.1"
 biometricKtx = "1.4.0-alpha02"
 navigationFragmentKtx = "2.9.0"
 navigationUiKtx = "2.9.0"
+cardviewV7 = "28.0.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -29,6 +30,7 @@ androidx-constraintlayout = { group = "androidx.constraintlayout", name = "const
 androidx-biometric-ktx = { group = "androidx.biometric", name = "biometric-ktx", version.ref = "biometricKtx" }
 androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
 androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigationUiKtx" }
+cardview-v7 = { group = "com.android.support", name = "cardview-v7", version.ref = "cardviewV7" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This commit adds the CardView v7 library as a project dependency.

The following changes were made:
- Added `cardviewV7 = "28.0.0"` to the `[versions]` section in `gradle/libs.versions.toml`.
- Added `cardview-v7 = { group = "com.android.support", name = "cardview-v7", version.ref = "cardviewV7" }` to the `[libraries]` section in `gradle/libs.versions.toml`.
- Added `implementation(libs.cardview.v7)` to the dependencies in `app/build.gradle.kts`.