### PR TITLE
Refactor: Use MaterialCardView for toolbar

### DIFF
--- a/app/src/main/res/layout/fragment_appointment_details.xml
+++ b/app/src/main/res/layout/fragment_appointment_details.xml
@@ -15,50 +15,54 @@
         android:background="@color/white">
 
         <!-- Toolbar -->
-        <androidx.cardview.widget.CardView
+        <!-- Toolbar -->
+        <com.google.android.material.card.MaterialCardView
             android:id="@+id/cardToolbar"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="-8dp"
-            android:layout_marginStart="5dp"
-            android:elevation="4dp"
-            app:cardCornerRadius="16dp"
-            app:cardPreventCornerOverlap="true"
-            app:layout_constraintTop_toTopOf="parent">
+            android:layout_height="115dp"
+            android:layout_marginTop="0dp"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            android:elevation="6dp"
+            app:cardElevation="6dp"
+            app:shapeAppearance="@style/ToolbarCardShape"
+            app:cardBackgroundColor="@color/grisOscuro"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
 
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="400dp"
-                android:layout_height="105dp"
-                android:background="@drawable/bg_toolbar">
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
                 <ImageView
                     android:id="@+id/backButton"
                     android:layout_width="100dp"
                     android:layout_height="34dp"
-                    android:layout_marginStart="16dp"
+                    android:layout_marginStart="1dp"
                     android:src="@drawable/ic_arrow_back"
+                    app:tint="@color/pink"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:tint="@color/pink"
                     tools:ignore="ContentDescription" />
 
                 <TextView
                     android:id="@+id/toolbarTitle"
-                    android:layout_width="167dp"
-                    android:layout_height="43dp"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
                     android:text="@{appointment.petName}"
-                    android:textColor="@color/white"
-                    android:textSize="24sp"
+                    android:textColor="@android:color/white"
+                    android:textSize="25sp"
                     android:textStyle="bold"
-                    app:layout_constraintBottom_toBottomOf="@id/backButton"
+                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintHorizontal_bias="0.504"
+                    app:layout_constraintHorizontal_bias="0.2"
                     app:layout_constraintStart_toEndOf="@id/backButton"
-                    app:layout_constraintTop_toTopOf="@id/backButton"
-                    app:layout_constraintVertical_bias="0.0" />
+                    app:layout_constraintTop_toTopOf="parent" />
             </androidx.constraintlayout.widget.ConstraintLayout>
-        </androidx.cardview.widget.CardView>
+        </com.google.android.material.card.MaterialCardView>
+
 
         <!-- Detalles de cita -->
         <androidx.cardview.widget.CardView


### PR DESCRIPTION
This commit updates the toolbar in `fragment_appointment_details.xml` to use `com.google.android.material.card.MaterialCardView` instead of `androidx.cardview.widget.CardView`.

This change introduces:
- A new shape appearance (`@style/ToolbarCardShape`) for the toolbar card.
- Adjusted layout parameters for margins, elevation, and background color to align with Material Design guidelines.
- Updated constraints and styling for the back button and toolbar title within the `MaterialCardView`.