### PR TITLE
Adjust layout constraints and remove placeholder text in appointment …

### DIFF
--- a/app/src/main/res/layout/fragment_appointment_details.xml
+++ b/app/src/main/res/layout/fragment_appointment_details.xml
@@ -37,7 +37,7 @@
                     android:id="@+id/backButton"
                     android:layout_width="100dp"
                     android:layout_height="34dp"
-                    android:layout_marginStart="2dp"
+                    android:layout_marginStart="1dp"
                     android:src="@drawable/ic_arrow_back"
                     app:tint="@color/pink"
                     app:layout_constraintBottom_toBottomOf="parent"
@@ -57,8 +57,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.2"
                     app:layout_constraintStart_toEndOf="@id/backButton"
-                    app:layout_constraintTop_toTopOf="parent"
-                    tools:text="NombreMascota" />
+                    app:layout_constraintTop_toTopOf="parent" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </com.google.android.material.card.MaterialCardView>
 
@@ -88,7 +87,7 @@
                     android:layout_gravity="end"
                     android:text="@{@string/turno_format(appointment.id)}"
                     android:textColor="@color/black"
-                    android:layout_marginTop="51dp"
+                    android:layout_marginTop="50dp"
                     android:textStyle="bold" />
 
                 <TextView
@@ -109,6 +108,7 @@
                     android:layout_marginTop="4dp"
                     android:text="@{appointment.symptom}" />
 
+                <!-- Línea divisoria -->
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="1dp"
@@ -180,6 +180,7 @@
                 android:scaleType="centerCrop"
                 tools:src="@drawable/ic_pet_placeholder" />
         </androidx.cardview.widget.CardView>
+
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/fabDelete"


### PR DESCRIPTION
…details

The `backButton`'s `layout_marginStart` was changed. The `tools:text` attribute was removed from the `petNameTextView` in the `appointment_details_header`. The `marginTop` for the `appointmentIdTextView` was changed. A comment indicating a "Línea divisoria" (Divider line) was added before a `View` element.